### PR TITLE
ipv6 → ip-address; use reverseForm

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "async": "^0.9.0",
     "colors": "^1.0.3",
     "extend": "^2.0.0",
-    "ipv6": "^3.1.1",
+    "ip-address": "^5.1.0",
     "lodash": "^3.5.0",
     "mailparser": "^0.5.1",
     "mkdirp": "^0.5.0",

--- a/plugins/rcpt/dnsbl.js
+++ b/plugins/rcpt/dnsbl.js
@@ -7,7 +7,7 @@ module.exports = {
 		// module dependencies
 		var net = require('net');
 		var dns = require('native-dns');
-		var ipv6 = require('ipv6').v6;
+		var Adress6 = require('ip-address').Address6;
 
 		// skip the check if the sender is authenticated
 		if (req.session.accepted.auth) {
@@ -43,11 +43,7 @@ module.exports = {
 
 		} else  if (net.isIPv6(ip)) {
 
-			// reverse the address by splitting the colons and filling the remaining space
-			reversed = new ipv6.Address(ip).parsedAddress.map(function(part) {
-				while(part.length < 4) part = '0' + part;
-				return part.split('').reverse().join('.');
-			}).reverse().join('.');
+			reversed = new Address6(ip).reverseForm({omitSuffix: true});
 
 		}
 


### PR DESCRIPTION
ipv6 is now deprecated; ip-address, its successor, contains a method to get the address in its reversed form :sparkles:
